### PR TITLE
Fixed issue with empty data in radio notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: 'main'
 on:
   push:
     branches:
-      - tauri-1
+      - main
 
 
 jobs:
@@ -30,8 +30,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev patchelf libxdo-dev libssl-dev dbus-x11 libcanberra-gtk3-module
-        # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
-        # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/README.md
+++ b/README.md
@@ -9,4 +9,11 @@ Requires mlterm for launching external shell menus.
 
 ## Recommended IDE Setup
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) in a Dev Container.
+
+## Build notes
+Commands should run normally from a Dev Container terminal prompt.
+- Run app from Dev Container: **npm run tauri dev**
+- Test build: **npx tauri dev**
+- Deployment build: **npx tauri build**
+

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -32,8 +32,9 @@ pub struct RadioInfo {
 
 #[derive(Deserialize)]
 struct RadioConfig {
+    #[serde(default)]
     notes: Vec<String>,
-    #[serde(rename = "fieldNotes")]
+    #[serde(default, rename = "fieldNotes")]
     field_notes: Vec<String>,
 }
 
@@ -253,9 +254,22 @@ pub fn get_radio_info() -> Result<RadioInfo, String> {
     let config: RadioConfig = serde_json::from_str(&contents)
         .map_err(|e| format!("Failed to parse radio config JSON: {}", e))?;
     // Return only the two needed sections
+    // Check if notes or field_notes are empty and assign "<No Notes>" if so
+    let notes = if config.notes.is_empty() {
+        vec!["No Notes".to_string()]
+    } else {
+        config.notes
+    };
+    
+    let field_notes = if config.field_notes.is_empty() {
+        vec!["No Notes".to_string()]
+    } else {
+        config.field_notes
+    };
+    
     Ok(RadioInfo {
-        notes: config.notes,
-        field_notes: config.field_notes,
+        notes,
+        field_notes,
     })
 }
 


### PR DESCRIPTION
Fixed issue with empty data in radio notes
Updated workflow target branch
Updated README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gracefully handle missing/empty radio notes by defaulting to "No Notes", update CI to run on `main`, and expand README with Dev Container/build instructions.
> 
> - **Backend (Tauri commands)**:
>   - `src-tauri/src/commands.rs`:
>     - `RadioConfig`: add `#[serde(default)]` for `notes` and `fieldNotes` to handle missing fields.
>     - `get_radio_info()`: default empty `notes`/`field_notes` to `"No Notes"` in returned `RadioInfo`.
> - **CI**:
>   - `.github/workflows/main.yml`: change push trigger branch to `main`.
> - **Docs**:
>   - `README.md`: note Dev Container setup and add build/run commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a764af10ade84e15b45c830b328b4f3aba36ea95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->